### PR TITLE
fix(olm): add versions field to 0.0.2 crd manifests

### DIFF
--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/common-template-bundles.crd.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/common-template-bundles.crd.yaml
@@ -11,5 +11,9 @@ spec:
     singular: kubevirtcommontemplatesbundle
   scope: Namespaced
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   subresources:
     status: {}

--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt.crd.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/kubevirt.crd.yaml
@@ -23,3 +23,7 @@ spec:
     singular: kubevirt
   scope: Namespaced
   version: v1alpha3
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true

--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/kwebui.crd.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/kwebui.crd.yaml
@@ -12,3 +12,7 @@ spec:
     singular: kwebui
   scope: Cluster
   version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/node-labeller-bundles.crd.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/node-labeller-bundles.crd.yaml
@@ -11,5 +11,9 @@ spec:
     singular: kubevirtnodelabellerbundle
   scope: Namespaced
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   subresources:
     status: {}

--- a/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/template-validator.crd.yaml
+++ b/deploy/converged/olm-catalog/kubevirt-hyperconverged/0.0.2/template-validator.crd.yaml
@@ -11,5 +11,9 @@ spec:
     singular: kubevirttemplatevalidator
   scope: Namespaced
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   subresources:
     status: {}


### PR DESCRIPTION
Adds the `versions` fields to `0.0.2` CRD manifests. This works around a [bug in OLM](https://bugzilla.redhat.com/show_bug.cgi?id=1732914) that affects respecting the deprecated `version` field, as well as prepping kubevirt manifests for multi-version support.